### PR TITLE
Exclude DateRange

### DIFF
--- a/lib/recurring_events.ex
+++ b/lib/recurring_events.ex
@@ -136,8 +136,19 @@ defmodule RecurringEvents do
     |> drop_after(rules)
   end
 
-  defp drop_exclude(dates, %{exclude_date: excludes}) do
-    dates |> Stream.filter(&(&1 not in excludes))
+  defp drop_exclude(dates, %{exclude_date: [%Elixir.Date{} | _] = excludes}) do
+    dates
+    |> Stream.filter(&(&1 not in excludes))
+  end
+
+  defp drop_exclude(dates, %{exclude_date: [%NaiveDateTime{} | _] = excludes}) do
+    dates
+    |> Stream.filter(&(&1 not in excludes))
+  end
+
+  defp drop_exclude(dates, %{exclude_date: [date_range]}) do
+    dates
+    |> Stream.reject(&Enum.any?(date_range, fn ex -> Date.compare(ex, &1) == :eq end))
   end
 
   defp drop_exclude(dates, _) do

--- a/test/ical_rrul_test.exs
+++ b/test/ical_rrul_test.exs
@@ -1232,6 +1232,23 @@ defmodule RR.IcalRrulTest do
     assert expect == result |> Enum.take(expect |> Enum.count())
   end
 
+  test "Test daily frequency with exclude date range" do
+    result =
+      ~N[2018-01-01 00:00:00]
+      |> RR.take(%{
+        freq: :daily,
+        exclude_date: Date.range(~D[2018-01-02], ~D[2018-01-04])
+      }, 5)
+
+    expect =
+      date_expand([
+        {{2018, 1, 1}, {0, 0, 0}},
+        {{2018, 1, 5}, {0, 0, 0}}
+      ])
+
+    assert expect == result |> Enum.take(5)
+  end
+
   test "1st, 2nd and 3rd week when week starts at wednesday" do
     result =
       ~D[2018-01-01]
@@ -1299,7 +1316,7 @@ defmodule RR.IcalRrulTest do
     assert expect == result |> Enum.take(expect |> Enum.count())
   end
 
-  describe "count shoud be resolbed after exclude dates" do
+  describe "count shoud be resolved after exclude dates" do
     test "when freq: :daily" do
       result =
         RR.take(

--- a/test/ical_rrul_test.exs
+++ b/test/ical_rrul_test.exs
@@ -1235,10 +1235,11 @@ defmodule RR.IcalRrulTest do
   test "Test daily frequency with exclude date range" do
     result =
       ~N[2018-01-01 00:00:00]
-      |> RR.take(%{
+      |> RR.unfold(%{
         freq: :daily,
         exclude_date: Date.range(~D[2018-01-02], ~D[2018-01-04])
-      }, 5)
+      })
+      |> Enum.take_while(&Date.compare(~D[2018-01-05], &1) != :lt)
 
     expect =
       date_expand([
@@ -1246,7 +1247,7 @@ defmodule RR.IcalRrulTest do
         {{2018, 1, 5}, {0, 0, 0}}
       ])
 
-    assert expect == result |> Enum.take(5)
+    assert expect == result
   end
 
   test "1st, 2nd and 3rd week when week starts at wednesday" do


### PR DESCRIPTION
Ref #10 

The added test is failing, because the expected behavior is not implemented.
If I ask for 5 recurrences, for a daily frequency, and 3 of these dates are excluded, I expect to get 2 dates. I shouldn't have to know beforehand about the effect of exclusions.

How would we solve this?

The `RecurringEvents.take` function could be changed to first do the `Enum.take` and then apply the `drop_exclude`.
