### PR TITLE
Feature/timezone support test cases

### DIFF
--- a/test/timezone_test.exs
+++ b/test/timezone_test.exs
@@ -4,7 +4,7 @@ defmodule RecurringEvents.TimezoneTest do
   alias RecurringEvents, as: RR
 
   if Code.ensure_loaded?(Timex) do
-    test "should handle timezones if Timex available" do
+    test "should handle timezones at the fall DST boundary" do
       time = Timex.to_datetime({{2018, 11, 2}, {5, 0, 0}}, "America/Los_Angeles")
 
       result =
@@ -17,6 +17,23 @@ defmodule RecurringEvents.TimezoneTest do
       assert result ==
                date_tz_expand(
                  [{{2018, 11, 2}, {5, 0, 0}}, {{2018, 11, 3..6}, {3, 0, 0}}],
+                 "America/Los_Angeles"
+               )
+    end
+
+    test "should handle timezones at the spring DST boundary" do
+      time = Timex.to_datetime({{2019, 3, 8}, {5, 0, 0}}, "America/Los_Angeles")
+
+      result =
+        RR.take(
+          time,
+          %{freq: :daily, by_hour: 3, by_minute: 0, by_second: 0},
+          5
+        )
+
+      assert result ==
+               date_tz_expand(
+                 [{{2019, 3, 8}, {5, 0, 0}}, {{2019, 3, 9..12}, {3, 0, 0}}],
                  "America/Los_Angeles"
                )
     end


### PR DESCRIPTION
This adds additional test cases to #15 to verify the correct behavior around  Daylight Saving Time boundaries.

Two of these tests are currently broken. They relate to times that would occur twice during the transition from daylight to standard time, or times that don't exist during the transition from standard to daylight time. These are explicitly detailed by [RFC5545](https://tools.ietf.org/html/rfc5545):

>   If, based on the definition of the referenced time zone, the local
>   time described occurs more than once (when changing from daylight
>   to standard time), the DATE-TIME value refers to the first
>   occurrence of the referenced time.  Thus, TZID=America/
>   New_York:20071104T013000 indicates November 4, 2007 at 1:30 A.M.
>   EDT (UTC-04:00).  If the local time described does not occur (when
>   changing from standard to daylight time), the DATE-TIME value is
>   interpreted using the UTC offset before the gap in local times.
>   Thus, TZID=America/New_York:20070311T023000 indicates March 11,
>   2007 at 3:30 A.M. EDT (UTC-04:00), one hour after 1:30 A.M. EST
>   (UTC-05:00).

Here is the spring behavior correctly implemented in Google Calendar:

<img width="779" alt="screen shot 2018-09-02 at 11 14 27 am" src="https://user-images.githubusercontent.com/114033/44959508-4f1d7400-aea4-11e8-93ce-9df3c89fc87a.png">

Here's the failure in this test as of now:

```
  1) test should handle timezones at the spring DST boundary for a 2:30 AM event (RecurringEvents.TimezoneTest)
     test/timezone_test.exs:70
     Assertion with == failed
     code:  assert result == date_tz_expand([{{2019, 3, 8}, {5, 0, 0}}, {{2019, 3, 9}, {2, 30, 0}}, {{2019, 3, 10}, {3, 30, 0}}, {{2019, 3, 11..12}, {2, 30, 0}}], "America/New_York")
     left:  [
              #DateTime<2019-03-08 05:00:00-05:00 EST America/New_York>,
              #DateTime<2019-03-09 02:30:00-05:00 EST America/New_York>,
              #DateTime<2019-03-10 02:30:00-04:00 EDT America/New_York>,
              #DateTime<2019-03-11 02:30:00-04:00 EDT America/New_York>,
              #DateTime<2019-03-12 02:30:00-04:00 EDT America/New_York>]
     right: [
              #DateTime<2019-03-08 05:00:00-05:00 EST America/New_York>,
              #DateTime<2019-03-09 02:30:00-05:00 EST America/New_York>,
              #DateTime<2019-03-10 03:30:00-04:00 EDT America/New_York>,
              #DateTime<2019-03-11 02:30:00-04:00 EDT America/New_York>,
              #DateTime<2019-03-12 02:30:00-04:00 EDT America/New_York>]
     stacktrace:
       test/timezone_test.exs:80: (test)
```

And the failure for the fall DST issue:

```
  2) test should handle timezones at the fall DST boundary for a 1:30 AM event (RecurringEvents.TimezoneTest)
     test/timezone_test.exs:24
     Assertion with == failed
     code:  assert result == date_tz_expand([{{2018, 11, 2}, {5, 0, 0}}, {{2018, 11, 3..6}, {1, 30, 0}}], "America/Los_Angeles")
     left:  [
              #DateTime<2018-11-02 05:00:00-07:00 PDT America/Los_Angeles>,
              #DateTime<2018-11-03 01:30:00-07:00 PDT America/Los_Angeles>,
              #DateTime<2018-11-04 01:30:00-08:00 PST America/Los_Angeles>,
              #DateTime<2018-11-05 01:30:00-08:00 PST America/Los_Angeles>,
              #DateTime<2018-11-06 01:30:00-08:00 PST America/Los_Angeles>]
     right: [
              #DateTime<2018-11-02 05:00:00-07:00 PDT America/Los_Angeles>,
              #DateTime<2018-11-03 01:30:00-07:00 PDT America/Los_Angeles>,
              #<Ambiguous(#DateTime<2018-11-04 01:30:00-07:00 PDT America/Los_Angeles> ~ #DateTime<2018-11-04 01:30:00-08:00 PST America/Los_Angeles>)>,
              #DateTime<2018-11-05 01:30:00-08:00 PST America/Los_Angeles>,
              #DateTime<2018-11-06 01:30:00-08:00 PST America/Los_Angeles>]
     stacktrace:
       test/timezone_test.exs:34: (test)
```

Note that the expected value here is also wrong because it has an ambiguous timezone result (since 1:30AM occurs twice). We likely need to explicitly choose the expected timezone for this result to make sure it is the UTC-7 / PDT value, not the UTC-8 PST value (or ambiguous).