### PR TITLE
Guard `count` argument in take/[2,3]

### DIFF
--- a/lib/recurring_events.ex
+++ b/lib/recurring_events.ex
@@ -108,8 +108,14 @@ defmodule RecurringEvents do
       [~D[2015-09-13], ~D[2015-10-13], ~D[2015-11-13], ~D[2015-12-13]]
 
   """
-  def take(date, rules, count) do
+  def take(date, rules, count) when count >= 0 do
     date |> unfold(rules) |> Enum.take(count)
+  end
+
+  def take(_date, _rules, count) do
+    raise ArgumentError,
+      message: "Expected a non-negative integer for `count`, " <>
+      "got #{count} instead."
   end
 
   @doc """

--- a/lib/recurring_events.ex
+++ b/lib/recurring_events.ex
@@ -112,10 +112,8 @@ defmodule RecurringEvents do
     date |> unfold(rules) |> Enum.take(count)
   end
 
-  def take(_date, _rules, count) do
-    raise ArgumentError,
-      message: "Expected a non-negative integer for `count`, " <>
-      "got #{count} instead."
+  def take(_date, _rules, _count) do
+    raise ArgumentError, message: "Count must be a non-negative integer."
   end
 
   @doc """
@@ -234,6 +232,9 @@ defmodule RecurringEvents do
       Map.has_key?(rules, :count) and Map.has_key?(rules, :until) ->
         raise ArgumentError, message: "Can have either, count or until"
 
+      !is_count_valid(rules) ->
+        raise ArgumentError, message: "Count must be a non-negative integer."
+
       !is_date(date) ->
         raise ArgumentError, message: "You have to use date or datetime structure"
 
@@ -244,4 +245,9 @@ defmodule RecurringEvents do
         nil
     end
   end
+
+  defp is_count_valid(%{count: nil}), do: true
+  defp is_count_valid(%{count: count}) when count >= 0, do: true
+  defp is_count_valid(%{count: count}) when count < 0, do: false
+  defp is_count_valid(%{}), do: true
 end

--- a/test/recurring_events_test.exs
+++ b/test/recurring_events_test.exs
@@ -41,6 +41,12 @@ defmodule RecurringEventsTest do
     end
   end
 
+  test "will raise an exception if count is invalid" do
+    assert_raise ArgumentError, fn ->
+      RR.take(@date, %{freq: :weekly}, -1)
+    end
+  end
+
   test "can handle yearly frequency" do
     events =
       @date

--- a/test/recurring_events_test.exs
+++ b/test/recurring_events_test.exs
@@ -43,7 +43,11 @@ defmodule RecurringEventsTest do
 
   test "will raise an exception if count is invalid" do
     assert_raise ArgumentError, fn ->
-      RR.take(@date, %{freq: :weekly}, -1)
+      RR.take(@date, @valid_rrule, -1)
+    end
+
+    assert_raise ArgumentError, fn ->
+      RR.unfold(@date, %{freq: :yearly, count: -1})
     end
   end
 


### PR DESCRIPTION
Giving a negative value to take/[2,3] would use VM resources until the
VM crashed. A guard was added to ensure `count` is 0 or greater and a
test was added to verify take[2,3] raises when given a negative value.