### PR TITLE
Allowing to return or skip invalid dates

### DIFF
--- a/lib/recurring_events.ex
+++ b/lib/recurring_events.ex
@@ -38,6 +38,11 @@ defmodule RecurringEvents do
       date withing frequency period
     - `:exclude_date` - dates to be excluded from the result
     - `:until` - limit result up to provided date
+    - `:invalid` - the way to handle invalid dates, `:fallback` by default. 
+      Options are:
+      - `:fallback` - falls back invalid dates to the last day of the month
+      - `:return` - returns the invalid date anyway
+      - `:skip` - skip the invalid date whatsoever
 
   For more usage examples, please, refer to
   [tests](https://github.com/pbogut/recurring_events/blob/master/test/ical_rrul_test.exs)
@@ -138,6 +143,19 @@ defmodule RecurringEvents do
     |> prepend(date)
     |> drop_exclude(rules)
     |> drop_after(rules)
+    |> drop_invalid(rules)
+  end
+
+  defp drop_invalid(dates, %{invalid: :skip}) do 
+    dates |> Stream.filter(&valid_date?/1)
+  end
+
+  defp drop_invalid(dates, _rules) do 
+    dates
+  end
+
+  defp valid_date?(date) do
+    Elixir.Date.new(date.year, date.month, date.day) != {:error, :invalid_date}
   end
 
   defp drop_exclude(dates, %{exclude_date: excludes}) do

--- a/lib/recurring_events/monthly.ex
+++ b/lib/recurring_events/monthly.ex
@@ -27,7 +27,8 @@ defmodule RecurringEvents.Monthly do
     Stream.resource(
       fn -> {date, 0} end,
       fn {date, iteration} ->
-        {[next_date], _} = next_result = next_iteration(date, step, iteration)
+        return_invalid = Map.get(rules, :invalid, :fallback) != :fallback
+        {[next_date], _} = next_result = next_iteration(date, step, iteration, return_invalid)
 
         cond do
           iteration == count -> {:halt, nil}
@@ -39,8 +40,8 @@ defmodule RecurringEvents.Monthly do
     )
   end
 
-  defp next_iteration(date, step, iteration) do
-    next_date = Date.shift_date(date, step * iteration, :months)
+  defp next_iteration(date, step, iteration, return_invalid) do
+    next_date = Date.shift_date( date, step * iteration, :months, return_invalid: return_invalid)
     acc = {date, iteration + 1}
     {[next_date], acc}
   end

--- a/test/recurring_events/date_test.exs
+++ b/test/recurring_events/date_test.exs
@@ -23,6 +23,7 @@ defmodule RecurringEvents.DateTest do
     assert ~N[2017-03-30 10:00:00] == Date.shift_date(@date, 2, :months)
     assert ~N[2017-06-30 10:00:00] == Date.shift_date(@date, 5, :months)
     assert ~N[2018-04-30 10:00:00] == Date.shift_date(@date, 15, :months)
+    assert %{@date | month: 2, day: 30} == Date.shift_date(@date, 1, :months, return_invalid: true)
   end
 
   test "can shift date by -N months" do

--- a/test/recurring_events_test.exs
+++ b/test/recurring_events_test.exs
@@ -93,4 +93,37 @@ defmodule RecurringEventsTest do
     assert is_list(list)
     assert list == Enum.take(stream, 29)
   end
+
+  test "can optionally return invalid dates" do
+    date = ~D[2020-10-31]
+
+    events =
+      date 
+      |> RR.unfold(%{freq: :monthly, invalid: :return})
+      |> Enum.take(2)
+    
+    assert events == [date, %{date | month: 11, day: 31}]
+  end
+
+  test "can optionally skip invalid dates" do
+    date = ~D[2020-10-31]
+
+    events =
+      date 
+      |> RR.unfold(%{freq: :monthly, invalid: :skip})
+      |> Enum.take(2)
+    
+    assert events == [date, %{date | month: 12, day: 31}]
+  end
+
+  test "can optionally skip invalid dates and respect count" do
+    date = ~D[2020-10-31]
+
+    events =
+      date 
+      |> RR.unfold(%{freq: :monthly, invalid: :skip, count: 3})
+      |> Enum.take(99)
+    
+    assert events == [date, %{date | month: 12, day: 31}]
+  end
 end


### PR DESCRIPTION
Closes #19 

On monthly repetitions, invalid dates like 2020-11-31 can be generated.

The way the lib was working until now was that it would fallback to the
last day of the month in that case, but as the RFC for RRULE has a
different take on that, I think it is a nice to have, at least as an
option.

So I added the `:invalid` option to the rules, allowing the devs either
get the invalid dates by setting it to `:return` or skipping them by
setting to `:skip`. Defaults to `:fallback`